### PR TITLE
Write to the ISO file descriptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ func main() {
     log.Fatalf("failed to create file: %s", err)
   }
 
-  err = writer.WriteTo(f)
+  err = writer.WriteTo(outputFile)
   if err != nil {
     log.Fatalf("failed to write ISO image: %s", err)
   }


### PR DESCRIPTION
Before:
```
$ go run readme.go
2019/12/07 16:56:52 failed to write ISO image: write myFile.txt: bad file descriptor
exit status 1
```
After:
```
$ go run readme.go
$ ls -al output.iso
-rw-r--r--@ 1 oozie  staff  0 Dec  7 16:56 output.iso
```