### PR TITLE
Add AddLocalFile function in image_writer

### DIFF
--- a/image_writer.go
+++ b/image_writer.go
@@ -89,7 +89,9 @@ func (iw *ImageWriter) AddLocalFile(origin, target string) error {
 
 	// try to hardlink file to staging area before copying.
 	stagedFile := path.Join(iw.stagingDir, directoryPath, fileName)
-	os.Remove(stagedFile)
+	if err := os.Remove(stagedFile); err != nil && !os.IsNotExist(err) {
+		return err
+	}
 
 	if err := os.Link(origin, stagedFile); err == nil {
 		return nil


### PR DESCRIPTION
AddLocalFile is for adding existing files in the filesystem to an ISO.
It first tries to hardlink the file to the staging area which can
provide speed-up. If hardlinking is not possible, it opens the
specified file and calls AddFile().

Even if hardlinking is never possible, it saves a few lines of codes
in many places because you don't need to handle the opening/closing
of files yourself.