### PR TITLE
Use uint32 to decode directory entry length

### DIFF
--- a/image_writer.go
+++ b/image_writer.go
@@ -165,7 +165,6 @@ func manglePath(input string) (string, string) {
 // @param {string} givenPath Path to convert
 //
 // @returns {string} Converted filepath
-//
 func posixifyPath(path string) string {
 	if runtime.GOOS == "windows" {
 		return strings.ReplaceAll(path, "\\", "/")
@@ -297,7 +296,7 @@ func (wc *writeContext) createDEForRoot() (*DirectoryEntry, error) {
 	de := &DirectoryEntry{
 		ExtendedAtributeRecordLength: 0,
 		ExtentLocation:               int32(extentLocation),
-		ExtentLength:                 int32(extentLengthInSectors * sectorSize),
+		ExtentLength:                 uint32(extentLengthInSectors * sectorSize),
 		RecordingDateTime:            wc.timestamp,
 		FileFlags:                    dirFlagDir,
 		FileUnitSize:                 0, // 0 for non-interleaved write
@@ -355,7 +354,7 @@ func (wc *writeContext) scanDirectory(item *itemToWrite, dirPath string, ownEntr
 		de := &DirectoryEntry{
 			ExtendedAtributeRecordLength: 0,
 			ExtentLocation:               int32(extentLocation),
-			ExtentLength:                 int32(extentLength),
+			ExtentLength:                 uint32(extentLength),
 			RecordingDateTime:            wc.timestamp,
 			FileFlags:                    fileFlags,
 			FileUnitSize:                 0, // 0 for non-interleaved write

--- a/iso9660.go
+++ b/iso9660.go
@@ -127,7 +127,7 @@ var _ encoding.BinaryMarshaler = PrimaryVolumeDescriptorBody{}
 type DirectoryEntry struct {
 	ExtendedAtributeRecordLength byte
 	ExtentLocation               int32
-	ExtentLength                 int32
+	ExtentLength                 uint32
 	RecordingDateTime            RecordingTimestamp
 	FileFlags                    byte
 	FileUnitSize                 byte
@@ -155,7 +155,7 @@ func (de *DirectoryEntry) UnmarshalBinary(data []byte) error {
 		return err
 	}
 
-	if de.ExtentLength, err = UnmarshalInt32LSBMSB(data[10:18]); err != nil {
+	if de.ExtentLength, err = UnmarshalUint32LSBMSB(data[10:18]); err != nil {
 		return err
 	}
 
@@ -196,7 +196,7 @@ func (de *DirectoryEntry) MarshalBinary() ([]byte, error) {
 	data[1] = de.ExtendedAtributeRecordLength
 
 	WriteInt32LSBMSB(data[2:10], de.ExtentLocation)
-	WriteInt32LSBMSB(data[10:18], de.ExtentLength)
+	WriteInt32LSBMSB(data[10:18], int32(de.ExtentLength))
 	de.RecordingDateTime.MarshalBinary(data[18:25])
 	data[25] = de.FileFlags
 	data[26] = de.FileUnitSize

--- a/iso9660_datatypes.go
+++ b/iso9660_datatypes.go
@@ -33,6 +33,12 @@ func UnmarshalInt32LSBMSB(data []byte) (int32, error) {
 	return lsb, nil
 }
 
+// UnmarshalUint32LSBMSB is the same as UnmarshalInt32LSBMSB but returns an unsigned integer
+func UnmarshalUint32LSBMSB(data []byte) (uint32, error) {
+	n, err := UnmarshalInt32LSBMSB(data)
+	return uint32(n), err
+}
+
 // UnmarshalInt16LSBMSB decodes a 16-bit integer in both byte orders, as defined in ECMA-119 7.3.3
 func UnmarshalInt16LSBMSB(data []byte) (int16, error) {
 	if len(data) < 4 {


### PR DESCRIPTION
Use unsigned integers for the ExtentLength field of directory entries.

I have a ISO file with a very large file in it (2.8GB), I had trouble reading that file with other tools so it could be that the ISO itself is not confromant or that other tools have this same bug. The ECMA standard is not clear on the signedness of the size field IMO. However I do not see the value of signed numbers for file length.