### PR TITLE
Fix crash when GetAllChildren returns nil,nil

### DIFF
--- a/image_reader.go
+++ b/image_reader.go
@@ -179,7 +179,7 @@ func (f *File) GetAllChildren() ([]*File, error) {
 	buffer := make([]byte, sectorSize)
 	for bytesProcessed := uint32(0); bytesProcessed < uint32(f.de.ExtentLength); bytesProcessed += sectorSize {
 		if _, err := f.ra.ReadAt(buffer, int64(baseOffset+bytesProcessed)); err != nil {
-			return nil, nil
+			return nil, err
 		}
 
 		for i := uint32(0); i < sectorSize; {
@@ -238,6 +238,9 @@ func (f *File) GetAllChildren() ([]*File, error) {
 
 			f.children = append(f.children, newFile)
 		}
+	}
+	if f.children == nil {
+		return nil, fmt.Errorf("no children found")
 	}
 
 	return f.children, nil


### PR DESCRIPTION
When GetAllChildren return nil, nil the following panic happens

panic: runtime error: makeslice: cap out of range

goroutine 1 [running]:
iso9660.(*File).GetChildren(0x54ec60?)

/home/tzachmann/develop/test/go/iso9660/src/iso9660/image_reader.go:254 +0x51

Here is the code that is problematic. When GetAllChildren returns nil, nil make with a size of -2 will be called which results in the above panic.

func (f *File) GetChildren() ([]*File, error) {
     children, err := f.GetAllChildren()
     if err != nil {
         return nil, err
     }

     filteredChildren := make([]*File, 0, len(children)-2)

This patch returns an error in case there are no children or the ReadAt fails.

If in this cases a nil, nil is fine the above code could be changed to

     filteredChildren := make([]*File, 0, len(children))

to fix the problem.