### PR TITLE
Fix endless loop in splitSystemUseEntries

### DIFF
--- a/susp.go
+++ b/susp.go
@@ -164,6 +164,8 @@ func splitSystemUseEntries(data []byte, ra io.ReaderAt) ([]SystemUseEntry, error
 		entryLen := int(data[2])
 		if len(data) < entryLen {
 			return nil, fmt.Errorf("splitting System Use entries: %w, expected %d bytes but have only %d", io.ErrUnexpectedEOF, entryLen, len(data))
+		} else if entryLen < 3 {
+			return output, nil
 		}
 
 		entry := SystemUseEntry(data[:entryLen])

--- a/susp_test.go
+++ b/susp_test.go
@@ -37,6 +37,11 @@ func TestEmptySU(t *testing.T) {
 	entries, err = splitSystemUseEntries(nil, ra)
 	assert.NoError(t, err)
 	assert.Len(t, entries, 0)
+
+	// CD-XA System Use Information
+	entries, err = splitSystemUseEntries([]byte{0, 0, 0, 0, 141, 85, 88, 65, 0, 0, 0, 0, 0, 0}, ra)
+	assert.NoError(t, err)
+	assert.Len(t, entries, 0)
 }
 
 func TestSUTooShort(t *testing.T) {


### PR DESCRIPTION
Fix endless loop in splitSystemUseEntries using all available memory. The problem happens on an iso where the system use was set to. 00 00 00 00 0d 55 58 41 00 00 00 00 00 00

This seems to be a CD-XA System Use Information.
The patch tests if the size of the SystemUseEntry is at least 3 bytes as defined in SUSP112 and if not an empty List of SystemUseEntry is returned.

Added a unit test that handles the case resulting in an endless loop.