### PR TITLE
Added alternative RockRidgeIdentifier 'IEEE_P1282', fixed a memory bug

### DIFF
--- a/iso9660.go
+++ b/iso9660.go
@@ -180,7 +180,9 @@ func (de *DirectoryEntry) UnmarshalBinary(data []byte) error {
 
 	// add padding if identifier length was even]
 	idPaddingLen := (identifierLen + 1) % 2
-	de.SystemUse = data[33+identifierLen+idPaddingLen : length]
+	systemUseData := data[33+identifierLen+idPaddingLen : length]
+	de.SystemUse = make([]byte, len(systemUseData))
+	copy(de.SystemUse, systemUseData)
 
 	return nil
 }

--- a/rockridge.go
+++ b/rockridge.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"slices"
 )
 
 /* The following types of Rock Ridge records are being handled in some way:
@@ -18,10 +19,9 @@ import (
  * - [ ] SF (RR 4.1.7: file data in sparse file format)
  */
 
-const (
-	RockRidgeIdentifier = "RRIP_1991A"
-	RockRidgeVersion    = 1
-)
+var RockRidgeIdentifiers = []string{"IEEE_P1282", "RRIP_1991A"}
+
+const RockRidgeVersion = 1
 
 type RockRidgeNameEntry struct {
 	Flags byte
@@ -35,7 +35,7 @@ func suspHasRockRidge(se SystemUseEntrySlice) (bool, error) {
 	}
 
 	for _, entry := range extensions {
-		if entry.Identifier == RockRidgeIdentifier && entry.Version == RockRidgeVersion {
+		if slices.Contains(RockRidgeIdentifiers, entry.Identifier) && entry.Version == RockRidgeVersion {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
Fixed incorrect SystemUse entries due to invalid pointer to a temporary buffer which is overwritten on every loop iteration. `UnmarshalBinary` of a `DirectoryEntry` should simply copy everything.